### PR TITLE
Parse settings strings for ENV variables and Craft Aliases

### DIFF
--- a/src/services/MoleculeService.php
+++ b/src/services/MoleculeService.php
@@ -40,7 +40,7 @@ class MoleculeService extends Component
             $filePath = "{$componentName}.twig";
         }
 
-        $fullFile = Molecule::$plugin->settings->pathComponent . $filePath;
+        $fullFile = Craft::parseEnv(Molecule::$plugin->settings->pathComponent) . $filePath;
 
         if (!is_readable($fullFile)) {
             throw new Exception("Your requested component at {$fullFile} could not be found.");
@@ -61,7 +61,7 @@ class MoleculeService extends Component
      */
     public function getIcon(string $iconName, array $iconVariables = [])
     {
-        $iconPath = Molecule::$plugin->settings->pathIcon . $iconName . '.svg';
+        $iconPath = Craft::parseEnv(Molecule::$plugin->settings->pathIcon) . $iconName . '.svg';
 
         if (!is_readable($iconPath)) {
             throw new Exception("Your requested icon at {$iconPath} could not be found.");

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,18 +15,22 @@
 
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'Component directory location',
     instructions: 'Enter the path to your components directory that Craft should read from.',
     id: 'pathComponent',
     name: 'pathComponent',
+    suggestEnvVars: true,
+    suggestAliases: true,
     value: settings['pathComponent']})
 }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'Icon directory location',
     instructions: 'Enter the path to your icon directory that Craft should read from.',
     id: 'pathIcon',
     name: 'pathIcon',
+    suggestEnvVars: true,
+    suggestAliases: true,
     value: settings['pathIcon']})
 }}


### PR DESCRIPTION
Use Craft's `parseEnv` method to replace ENV variables and aliases in the settings string so we can do something like `@root/components/` for directory locations.